### PR TITLE
chore: update npm dependencies

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -536,9 +536,9 @@ acorn@^5.5.3:
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
 acorn@^6.0.1:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
-  integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.0.tgz#b659d2ffbafa24baf5db1cdbb2c94a983ecd2784"
+  integrity sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==
 
 acorn@^7.1.0:
   version "7.1.0"
@@ -695,9 +695,9 @@ aws-sign2@~0.7.0:
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
-  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.0.tgz#24390e6ad61386b0a747265754d2a17219de862c"
+  integrity sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==
 
 babel-jest@^24.9.0:
   version "24.9.0"
@@ -3419,9 +3419,9 @@ resolve@1.1.7:
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 resolve@1.x, resolve@^1.10.0, resolve@^1.3.2:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.0.tgz#e879eb397efb40511056ede7300b6ac28c51290b"
-  integrity sha512-HHZ3hmOrk5SvybTb18xq4Ek2uLqLO5/goFCYUyvn26nWox4hdlKlfC/+dChIZ6qc4ZeYcN9ekTz0yyHsFgumMw==
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.1.tgz#be0aa4c06acd53083505abb35f4d66932ab35d16"
+  integrity sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
## Base PullRequest

chore: update npm dependencies (#56)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>sudo yarn global add npm-check-updates</em></summary>

```Shell
yarn global v1.19.1
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Installed "npm-check-updates@3.2.2" with binaries:
      - npm-check-updates
      - ncu
Done in 5.16s.
```



</details>
<details>
<summary><em>ncu -u --packageFile package.json</em></summary>

```Shell
Upgrading /home/runner/work/ts-package-template/ts-package-template/package.json

All dependencies match the latest package versions :)
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.19.1
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.9: The platform "linux" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 14.29s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.19.1
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.9: The platform "linux" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 358 new dependencies.
info Direct dependencies
├─ @technote-space/github-action-test-helper@0.0.25
├─ @types/jest@24.0.23
├─ @types/node@12.12.14
├─ @typescript-eslint/eslint-plugin@2.9.0
├─ @typescript-eslint/parser@2.9.0
├─ eslint@6.7.1
├─ jest-circus@24.9.0
├─ jest@24.9.0
├─ ts-jest@24.2.0
└─ typescript@3.7.2
info All dependencies
├─ @actions/github@1.1.0
├─ @babel/generator@7.7.4
├─ @babel/helper-function-name@7.7.4
├─ @babel/helper-get-function-arity@7.7.4
├─ @babel/helper-split-export-declaration@7.7.4
├─ @babel/helpers@7.7.4
├─ @babel/highlight@7.5.0
├─ @babel/plugin-syntax-object-rest-spread@7.7.4
├─ @cnakazawa/watch@1.0.3
├─ @jest/core@24.9.0
├─ @jest/reporters@24.9.0
├─ @jest/source-map@24.9.0
├─ @jest/test-sequencer@24.9.0
├─ @octokit/endpoint@5.5.1
├─ @octokit/graphql@2.1.3
├─ @octokit/request-error@1.2.0
├─ @octokit/request@5.3.1
├─ @octokit/rest@16.35.0
├─ @technote-space/github-action-test-helper@0.0.25
├─ @types/babel__core@7.1.3
├─ @types/babel__generator@7.6.0
├─ @types/babel__template@7.0.2
├─ @types/babel__traverse@7.0.8
├─ @types/eslint-visitor-keys@1.0.0
├─ @types/istanbul-lib-report@1.1.1
├─ @types/istanbul-reports@1.1.1
├─ @types/jest@24.0.23
├─ @types/json-schema@7.0.3
├─ @types/node@12.12.14
├─ @types/stack-utils@1.0.1
├─ @types/yargs-parser@13.1.0
├─ @typescript-eslint/eslint-plugin@2.9.0
├─ @typescript-eslint/parser@2.9.0
├─ acorn-globals@4.3.4
├─ acorn-jsx@5.1.0
├─ acorn-walk@6.2.0
├─ acorn@7.1.0
├─ ajv@6.10.2
├─ ansi-regex@4.1.0
├─ argparse@1.0.10
├─ arr-flatten@1.1.0
├─ array-equal@1.0.0
├─ asn1@0.2.4
├─ assign-symbols@1.0.0
├─ async-limiter@1.0.1
├─ asynckit@0.4.0
├─ atob-lite@2.0.0
├─ atob@2.1.2
├─ aws-sign2@0.7.0
├─ aws4@1.9.0
├─ babel-jest@24.9.0
├─ babel-plugin-jest-hoist@24.9.0
├─ babel-preset-jest@24.9.0
├─ balanced-match@1.0.0
├─ base@0.11.2
├─ bcrypt-pbkdf@1.0.2
├─ before-after-hook@2.1.0
├─ brace-expansion@1.1.11
├─ braces@2.3.2
├─ browser-process-hrtime@0.1.3
├─ browser-resolve@1.11.3
├─ bs-logger@0.2.6
├─ bser@2.1.1
├─ btoa-lite@1.0.0
├─ buffer-from@1.1.1
├─ cache-base@1.0.1
├─ camelcase@5.3.1
├─ capture-exit@2.0.0
├─ caseless@0.12.0
├─ chardet@0.7.0
├─ ci-info@2.0.0
├─ class-utils@0.3.6
├─ cli-cursor@3.1.0
├─ cli-width@2.2.0
├─ cliui@5.0.0
├─ collection-visit@1.0.0
├─ color-convert@1.9.3
├─ color-name@1.1.3
├─ combined-stream@1.0.8
├─ commander@2.20.3
├─ concat-map@0.0.1
├─ convert-source-map@1.7.0
├─ copy-descriptor@0.1.1
├─ core-util-is@1.0.2
├─ cross-spawn@6.0.5
├─ cssom@0.3.8
├─ cssstyle@1.4.0
├─ dashdash@1.14.1
├─ data-urls@1.1.0
├─ decamelize@1.2.0
├─ decode-uri-component@0.2.0
├─ deep-is@0.1.3
├─ delayed-stream@1.0.0
├─ detect-newline@2.1.0
├─ diff-sequences@24.9.0
├─ doctrine@3.0.0
├─ domexception@1.0.1
├─ ecc-jsbn@0.1.2
├─ emoji-regex@7.0.3
├─ end-of-stream@1.4.4
├─ error-ex@1.3.2
├─ es-abstract@1.16.2
├─ es-to-primitive@1.2.1
├─ escodegen@1.12.0
├─ eslint@6.7.1
├─ espree@6.1.2
├─ esprima@4.0.1
├─ esquery@1.0.1
├─ esrecurse@4.2.1
├─ estraverse@4.3.0
├─ expand-brackets@2.1.4
├─ extend@3.0.2
├─ external-editor@3.1.0
├─ extglob@2.0.4
├─ extsprintf@1.3.0
├─ fast-deep-equal@2.0.1
├─ fast-levenshtein@2.0.6
├─ figures@3.1.0
├─ file-entry-cache@5.0.1
├─ fill-range@4.0.0
├─ flat-cache@2.0.1
├─ flatted@2.0.1
├─ for-in@1.0.2
├─ forever-agent@0.6.1
├─ form-data@2.3.3
├─ fs.realpath@1.0.0
├─ get-caller-file@2.0.5
├─ get-stream@4.1.0
├─ getpass@0.1.7
├─ glob-parent@5.1.0
├─ globals@12.3.0
├─ graceful-fs@4.2.3
├─ growly@1.3.0
├─ handlebars@4.5.3
├─ har-schema@2.0.0
├─ har-validator@5.1.3
├─ has-value@1.0.0
├─ has@1.0.3
├─ hosted-git-info@2.8.5
├─ html-encoding-sniffer@1.0.2
├─ http-signature@1.2.0
├─ iconv-lite@0.4.24
├─ ignore@4.0.6
├─ import-fresh@3.2.1
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ inquirer@7.0.0
├─ invariant@2.2.4
├─ is-accessor-descriptor@1.0.0
├─ is-arrayish@0.2.1
├─ is-data-descriptor@1.0.0
├─ is-date-object@1.0.1
├─ is-descriptor@1.0.2
├─ is-extglob@2.1.1
├─ is-fullwidth-code-point@2.0.0
├─ is-plain-object@2.0.4
├─ is-promise@2.1.0
├─ is-regex@1.0.4
├─ is-stream@1.1.0
├─ is-symbol@1.0.3
├─ is-typedarray@1.0.0
├─ is-windows@1.0.2
├─ is-wsl@1.1.0
├─ isarray@1.0.0
├─ isexe@2.0.0
├─ isstream@0.1.2
├─ istanbul-lib-instrument@3.3.0
├─ istanbul-lib-report@2.0.8
├─ istanbul-lib-source-maps@3.0.6
├─ istanbul-reports@2.2.6
├─ jest-changed-files@24.9.0
├─ jest-circus@24.9.0
├─ jest-cli@24.9.0
├─ jest-docblock@24.9.0
├─ jest-environment-jsdom@24.9.0
├─ jest-environment-node@24.9.0
├─ jest-leak-detector@24.9.0
├─ jest-pnp-resolver@1.2.1
├─ jest-resolve-dependencies@24.9.0
├─ jest-serializer@24.9.0
├─ jest-watcher@24.9.0
├─ jest-worker@24.9.0
├─ jest@24.9.0
├─ js-tokens@4.0.0
├─ jsdom@11.12.0
├─ jsesc@2.5.2
├─ json-parse-better-errors@1.0.2
├─ json-schema-traverse@0.4.1
├─ json-schema@0.2.3
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json-stringify-safe@5.0.1
├─ json5@2.1.1
├─ jsprim@1.4.1
├─ kind-of@3.2.2
├─ kleur@3.0.3
├─ left-pad@1.3.0
├─ leven@3.1.0
├─ levn@0.3.0
├─ load-json-file@4.0.0
├─ locate-path@3.0.0
├─ lodash.get@4.4.2
├─ lodash.memoize@4.1.2
├─ lodash.set@4.3.2
├─ lodash.unescape@4.0.1
├─ lodash.uniq@4.5.0
├─ loose-envify@1.4.0
├─ macos-release@2.3.0
├─ make-error@1.3.5
├─ makeerror@1.0.11
├─ map-visit@1.0.0
├─ merge-stream@2.0.0
├─ mime-db@1.42.0
├─ mime-types@2.1.25
├─ mimic-fn@2.1.0
├─ minimatch@3.0.4
├─ minimist@1.2.0
├─ mixin-deep@1.3.2
├─ mkdirp@0.5.1
├─ ms@2.1.2
├─ mute-stream@0.0.8
├─ nanomatch@1.2.13
├─ neo-async@2.6.1
├─ nice-try@1.0.5
├─ node-fetch@2.6.0
├─ node-int64@0.4.0
├─ node-modules-regexp@1.0.0
├─ node-notifier@5.4.3
├─ normalize-package-data@2.5.0
├─ normalize-path@2.1.1
├─ npm-run-path@2.0.2
├─ nwsapi@2.2.0
├─ oauth-sign@0.9.0
├─ object-copy@0.1.0
├─ object-inspect@1.7.0
├─ object-keys@1.1.1
├─ object.getownpropertydescriptors@2.0.3
├─ octokit-pagination-methods@1.1.0
├─ onetime@5.1.0
├─ optimist@0.6.1
├─ optionator@0.8.3
├─ os-name@3.1.0
├─ os-tmpdir@1.0.2
├─ p-each-series@1.0.0
├─ p-finally@1.0.0
├─ p-limit@2.2.1
├─ p-locate@3.0.0
├─ p-reduce@1.0.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ parse-json@4.0.0
├─ parse5@4.0.0
├─ pascalcase@0.1.1
├─ path-exists@3.0.0
├─ path-is-absolute@1.0.1
├─ path-key@2.0.1
├─ path-parse@1.0.6
├─ path-type@3.0.0
├─ performance-now@2.1.0
├─ pirates@4.0.1
├─ pkg-dir@3.0.0
├─ pn@1.1.0
├─ posix-character-classes@0.1.1
├─ progress@2.0.3
├─ prompts@2.3.0
├─ psl@1.4.0
├─ pump@3.0.0
├─ qs@6.5.2
├─ react-is@16.12.0
├─ read-pkg-up@4.0.0
├─ read-pkg@3.0.0
├─ regexpp@2.0.1
├─ remove-trailing-separator@1.1.0
├─ repeat-element@1.1.3
├─ request-promise-core@1.1.3
├─ request-promise-native@1.0.8
├─ request@2.88.0
├─ require-directory@2.1.1
├─ resolve-cwd@2.0.0
├─ resolve-from@4.0.0
├─ resolve-url@0.2.1
├─ resolve@1.13.1
├─ restore-cursor@3.1.0
├─ ret@0.1.15
├─ rimraf@2.7.1
├─ rsvp@4.8.5
├─ run-async@2.3.0
├─ rxjs@6.5.3
├─ safer-buffer@2.1.2
├─ sane@4.1.0
├─ sax@1.2.4
├─ semver@5.7.1
├─ set-blocking@2.0.0
├─ set-value@2.0.1
├─ shebang-command@1.2.0
├─ shebang-regex@1.0.0
├─ shellwords@0.1.1
├─ signal-exit@3.0.2
├─ sisteransi@1.0.4
├─ slice-ansi@2.1.0
├─ snapdragon-node@2.1.1
├─ snapdragon-util@3.0.1
├─ source-map-resolve@0.5.2
├─ source-map-support@0.5.16
├─ source-map-url@0.4.0
├─ spdx-correct@3.1.0
├─ spdx-exceptions@2.2.0
├─ split-string@3.1.0
├─ sprintf-js@1.0.3
├─ sshpk@1.16.1
├─ static-extend@0.1.2
├─ stealthy-require@1.1.1
├─ string.prototype.trimleft@2.1.0
├─ string.prototype.trimright@2.1.0
├─ strip-eof@1.0.0
├─ strip-json-comments@3.0.1
├─ symbol-tree@3.2.4
├─ table@5.4.6
├─ test-exclude@5.2.3
├─ text-table@0.2.0
├─ through@2.3.8
├─ tmp@0.0.33
├─ to-fast-properties@2.0.0
├─ to-object-path@0.3.0
├─ to-regex-range@2.1.1
├─ tough-cookie@2.5.0
├─ ts-jest@24.2.0
├─ tslib@1.10.0
├─ tunnel-agent@0.6.0
├─ tweetnacl@0.14.5
├─ typescript@3.7.2
├─ uglify-js@3.7.0
├─ union-value@1.0.1
├─ unset-value@1.0.0
├─ uri-js@4.2.2
├─ urix@0.1.0
├─ use@3.1.1
├─ util.promisify@1.0.0
├─ uuid@3.3.3
├─ v8-compile-cache@2.1.0
├─ validate-npm-package-license@3.0.4
├─ verror@1.10.0
├─ w3c-hr-time@1.0.1
├─ walker@1.0.7
├─ whatwg-encoding@1.0.5
├─ whatwg-mimetype@2.3.0
├─ whatwg-url@6.5.0
├─ which-module@2.0.0
├─ which@1.3.1
├─ windows-release@3.2.0
├─ word-wrap@1.2.3
├─ wordwrap@0.0.3
├─ wrap-ansi@5.1.0
├─ write-file-atomic@2.4.1
├─ write@1.0.3
├─ ws@5.2.2
├─ xml-name-validator@3.0.0
├─ y18n@4.0.0
└─ yargs-parser@10.1.0
Done in 4.93s.
```

### stderr:

```Shell
warning jest > jest-cli > @jest/core > jest-haste-map > fsevents@1.2.9: One of your dependencies needs to upgrade to fsevents v2: 1) Proper nodejs v10+ support 2) No more fetching binaries from AWS, smaller package size
warning jest > jest-cli > jest-config > jest-environment-jsdom > jsdom > left-pad@1.3.0: use String.prototype.padStart()
```

</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.19.1
0 vulnerabilities found - Packages audited: 891399
Done in 1.13s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)