### PR TITLE
release: v0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
   "devDependencies": {
     "@commitlint/cli": "^16.2.3",
     "@commitlint/config-conventional": "^16.2.1",
-    "@types/node": "^17.0.23",
+    "@types/node": "^17.0.24",
     "@typescript-eslint/eslint-plugin": "^5.19.0",
     "@typescript-eslint/parser": "^5.19.0",
     "c8": "^7.11.0",
     "eslint": "^8.13.0",
     "eslint-plugin-import": "^2.26.0",
     "husky": "^7.0.4",
-    "lint-staged": "^12.3.7",
+    "lint-staged": "^12.3.8",
     "pinst": "^3.0.0",
     "typescript": "^4.6.3",
     "vitest": "^0.9.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/ts-package-template",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Template for npm package.",
   "keywords": [
     "template"

--- a/src/constant.test.ts
+++ b/src/constant.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { WAIT_MS, INTERVAL_MS } from './constant';
+
+describe('INTERVAL_MS', () => {
+  it('should return actual value', () => {
+    expect(INTERVAL_MS).toBe(1000);
+  });
+});
+
+describe('WAIT_MS', () => {
+  it('should return mocked value', () => {
+    expect(WAIT_MS).toBe(0);
+  });
+});

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,1 +1,2 @@
 export const WAIT_MS = 1000;
+export const INTERVAL_MS = 1000;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 
-vi.mock('./src/constant', () => Object.assign(vi.importActual('./src/constant'), {
-  INTERVAL_MS: 0,
+vi.mock('./constant', async() => ({
+  ...await vi.importActual<{ INTERVAL_MS: number }>('./constant'),
+  WAIT_MS: 0,
 }));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,9 @@
 /// <reference types="vitest" />
-
 import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   test: {
-    globals: true,
     setupFiles: './src/setup.ts',
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2822,9 +2822,9 @@ validate-npm-package-license@^3.0.1:
     spdx-expression-parse "^3.0.0"
 
 vite@^2.9.1:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.2.tgz#bf233b96c77beae7c4a4674d76ece678588620f3"
-  integrity sha512-ScbfYsiG1N/xE2TnZWYWJ8aOFBQovEl4VLU+0dktxqXvqdAvcTOEUM5YqwaBkmNHSHUGHLPd92tuXFQ35wDkVw==
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.3.tgz#29a887bc21a2f90043f800618cb6848e861a604c"
+  integrity sha512-R9IrnWGallcXvOeWa1AA7CH9MdW/9X+cj3c11IHcq98OkNSzWzwb0dd69DvEZTIdxJNOZL3kHRCWC7L2QH0sNw==
   dependencies:
     esbuild "^0.14.27"
     postcss "^8.4.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -275,9 +275,9 @@
     "@types/chai" "*"
 
 "@types/chai@*", "@types/chai@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
-  integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
+  integrity sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==
 
 "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
@@ -299,10 +299,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@>=12", "@types/node@^17.0.23":
-  version "17.0.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
-  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
+"@types/node@>=12", "@types/node@^17.0.24":
+  version "17.0.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.24.tgz#20ba1bf69c1b4ab405c7a01e950c4f446b05029f"
+  integrity sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -832,11 +832,12 @@ deep-is@^0.1.3:
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 define-properties@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
-  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
+  integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
   dependencies:
-    object-keys "^1.0.12"
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
 
 diff@^4.0.1:
   version "4.0.2"
@@ -894,9 +895,9 @@ error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.19.1, es-abstract@^1.19.2:
-  version "1.19.4"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.4.tgz#79a95527af382eb276075627e53762393ce8b57a"
-  integrity sha512-flV8e5g9/xulChMG48Fygk1ptpo4lQRJ0eJYtxJFgi7pklLx7EFcOJ34jnvr8pbWlaFN/AT1cZpe0hiFel9Hqg==
+  version "1.19.5"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.5.tgz#a2cb01eb87f724e815b278b0dd0d00f36ca9a7f1"
+  integrity sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==
   dependencies:
     call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
@@ -1478,6 +1479,13 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
+
 has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
@@ -1808,10 +1816,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-lint-staged@^12.3.7:
-  version "12.3.7"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-12.3.7.tgz#ad0e2014302f704f9cf2c0ebdb97ac63d0f17be0"
-  integrity sha512-/S4D726e2GIsDVWIk1XGvheCaDm1SJRQp8efamZFWJxQMVEbOwSysp7xb49Oo73KYCdy97mIWinhlxcoNqIfIQ==
+lint-staged@^12.3.8:
+  version "12.3.8"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-12.3.8.tgz#ee3fe2e16c9d76f99d8348072900b017d6d76901"
+  integrity sha512-0+UpNaqIwKRSGAFOCcpuYNIv/j5QGVC+xUVvmSdxHO+IfIGoHbFLo3XcPmV/LLnsVj5EAncNHVtlITSoY5qWGQ==
   dependencies:
     cli-truncate "^3.1.0"
     colorette "^2.0.16"
@@ -2053,7 +2061,7 @@ object-inspect@^1.12.0, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
 
-object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -2366,9 +2374,9 @@ rimraf@^3.0.0, rimraf@^3.0.2:
     glob "^7.1.3"
 
 rollup@^2.59.0:
-  version "2.70.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.1.tgz#824b1f1f879ea396db30b0fc3ae8d2fead93523e"
-  integrity sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==
+  version "2.70.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.2.tgz#808d206a8851628a065097b7ba2053bd83ba0c0d"
+  integrity sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -2795,9 +2803,9 @@ util-deprecate@^1.0.1:
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 v8-compile-cache-lib@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz#0582bcb1c74f3a2ee46487ceecf372e46bce53e8"
-  integrity sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"
@@ -2822,9 +2830,9 @@ validate-npm-package-license@^3.0.1:
     spdx-expression-parse "^3.0.0"
 
 vite@^2.9.1:
-  version "2.9.3"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.3.tgz#29a887bc21a2f90043f800618cb6848e861a604c"
-  integrity sha512-R9IrnWGallcXvOeWa1AA7CH9MdW/9X+cj3c11IHcq98OkNSzWzwb0dd69DvEZTIdxJNOZL3kHRCWC7L2QH0sNw==
+  version "2.9.5"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.5.tgz#08ef37ac7a6d879c96f328b791732c9a00ea25ea"
+  integrity sha512-dvMN64X2YEQgSXF1lYabKXw3BbN6e+BL67+P3Vy4MacnY+UzT1AfkHiioFSi9+uiDUiaDy7Ax/LQqivk6orilg==
   dependencies:
     esbuild "^0.14.27"
     postcss "^8.4.12"


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (bf7bdf1b47216f5bef357eb8fbd90daf2ad0c902)
* chore: tweaks (f2525a0e3950ee971ffe09ff054e35f3c759ce3d)
* chore: add test pattern (0d943f661adf5de538a01f401ce581a6f6ea1fc2)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/ts-package-template/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>cli.js -u --packageFile package.json</em></summary>

```Shell
Using yarn
Upgrading /home/runner/work/ts-package-template/ts-package-template/package.json

All dependencies match the latest package versions :)
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.18
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
$ [ -n "$CI" ] || [ ! -f node_modules/.bin/husky ] || husky install
Done in 10.16s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.18
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 279 new dependencies.
info Direct dependencies
├─ @commitlint/cli@16.2.3
├─ @commitlint/config-conventional@16.2.1
├─ @types/node@17.0.23
├─ @typescript-eslint/eslint-plugin@5.19.0
├─ @typescript-eslint/parser@5.19.0
├─ c8@7.11.0
├─ eslint-plugin-import@2.26.0
├─ eslint@8.13.0
├─ husky@7.0.4
├─ lint-staged@12.3.7
├─ pinst@3.0.0
├─ typescript@4.6.3
└─ vitest@0.9.3
info All dependencies
├─ @babel/code-frame@7.16.7
├─ @babel/helper-validator-identifier@7.16.7
├─ @babel/highlight@7.17.9
├─ @bcoe/v8-coverage@0.2.3
├─ @commitlint/cli@16.2.3
├─ @commitlint/config-conventional@16.2.1
├─ @commitlint/ensure@16.2.1
├─ @commitlint/execute-rule@16.2.1
├─ @commitlint/format@16.2.1
├─ @commitlint/is-ignored@16.2.1
├─ @commitlint/lint@16.2.1
├─ @commitlint/load@16.2.3
├─ @commitlint/message@16.2.1
├─ @commitlint/parse@16.2.1
├─ @commitlint/read@16.2.1
├─ @commitlint/resolve-extends@16.2.1
├─ @commitlint/rules@16.2.1
├─ @commitlint/to-lines@16.2.1
├─ @commitlint/top-level@16.2.1
├─ @cspotcode/source-map-consumer@0.8.0
├─ @cspotcode/source-map-support@0.7.0
├─ @eslint/eslintrc@1.2.1
├─ @humanwhocodes/config-array@0.9.5
├─ @humanwhocodes/object-schema@1.2.1
├─ @nodelib/fs.scandir@2.1.5
├─ @nodelib/fs.stat@2.0.5
├─ @nodelib/fs.walk@1.2.8
├─ @tsconfig/node10@1.0.8
├─ @tsconfig/node12@1.0.9
├─ @tsconfig/node14@1.0.1
├─ @tsconfig/node16@1.0.2
├─ @types/chai-subset@1.3.3
├─ @types/chai@4.3.0
├─ @types/istanbul-lib-coverage@2.0.4
├─ @types/json-schema@7.0.11
├─ @types/json5@0.0.29
├─ @types/minimist@1.2.2
├─ @types/node@17.0.23
├─ @types/normalize-package-data@2.4.1
├─ @types/parse-json@4.0.0
├─ @typescript-eslint/eslint-plugin@5.19.0
├─ @typescript-eslint/parser@5.19.0
├─ @typescript-eslint/type-utils@5.19.0
├─ acorn-jsx@5.3.2
├─ acorn-walk@8.2.0
├─ acorn@8.7.0
├─ aggregate-error@3.1.0
├─ ajv@6.12.6
├─ ansi-escapes@4.3.2
├─ ansi-regex@5.0.1
├─ arg@4.1.3
├─ argparse@2.0.1
├─ array-ify@1.0.0
├─ array-includes@3.1.4
├─ array-union@2.1.0
├─ array.prototype.flat@1.3.0
├─ arrify@1.0.1
├─ assertion-error@1.1.0
├─ balanced-match@1.0.2
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ c8@7.11.0
├─ callsites@3.1.0
├─ camelcase-keys@6.2.2
├─ camelcase@5.3.1
├─ chai@4.3.6
├─ check-error@1.0.2
├─ clean-stack@2.2.0
├─ cli-cursor@3.1.0
├─ cli-truncate@3.1.0
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ commander@8.3.0
├─ concat-map@0.0.1
├─ conventional-changelog-angular@5.0.13
├─ conventional-changelog-conventionalcommits@4.6.3
├─ conventional-commits-parser@3.2.4
├─ convert-source-map@1.8.0
├─ cosmiconfig-typescript-loader@1.0.9
├─ cosmiconfig@7.0.1
├─ create-require@1.1.1
├─ cross-spawn@7.0.3
├─ dargs@7.0.0
├─ debug@4.3.4
├─ decamelize-keys@1.1.0
├─ decamelize@1.2.0
├─ deep-eql@3.0.1
├─ deep-is@0.1.4
├─ diff@4.0.2
├─ dir-glob@3.0.1
├─ doctrine@2.1.0
├─ dot-prop@5.3.0
├─ eastasianwidth@0.2.0
├─ emoji-regex@8.0.0
├─ error-ex@1.3.2
├─ es-shim-unscopables@1.0.0
├─ es-to-primitive@1.2.1
├─ esbuild-linux-64@0.14.36
├─ esbuild@0.14.36
├─ escape-string-regexp@4.0.0
├─ eslint-import-resolver-node@0.3.6
├─ eslint-module-utils@2.7.3
├─ eslint-plugin-import@2.26.0
├─ eslint-scope@7.1.1
├─ eslint@8.13.0
├─ esquery@1.4.0
├─ estraverse@5.3.0
├─ execa@5.1.1
├─ fast-deep-equal@3.1.3
├─ fast-glob@3.2.11
├─ fast-json-stable-stringify@2.1.0
├─ fast-levenshtein@2.0.6
├─ fastq@1.13.0
├─ file-entry-cache@6.0.1
├─ fill-range@7.0.1
├─ flat-cache@3.0.4
├─ flatted@3.2.5
├─ foreground-child@2.0.0
├─ fs-extra@10.0.1
├─ fs.realpath@1.0.0
├─ get-stream@6.0.1
├─ get-symbol-description@1.0.0
├─ git-raw-commits@2.0.11
├─ glob-parent@6.0.2
├─ glob@7.2.0
├─ global-dirs@0.1.1
├─ globals@13.13.0
├─ globby@11.1.0
├─ graceful-fs@4.2.10
├─ hard-rejection@2.1.0
├─ has-flag@4.0.0
├─ hosted-git-info@4.1.0
├─ html-escaper@2.0.2
├─ human-signals@2.1.0
├─ husky@7.0.4
├─ imurmurhash@0.1.4
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ ini@1.3.8
├─ internal-slot@1.0.3
├─ is-arrayish@0.2.1
├─ is-bigint@1.0.4
├─ is-boolean-object@1.1.2
├─ is-callable@1.2.4
├─ is-date-object@1.0.5
├─ is-extglob@2.1.1
├─ is-negative-zero@2.0.2
├─ is-number-object@1.0.7
├─ is-number@7.0.0
├─ is-obj@2.0.0
├─ is-plain-obj@1.1.0
├─ is-regex@1.1.4
├─ is-shared-array-buffer@1.0.2
├─ is-stream@2.0.1
├─ is-string@1.0.7
├─ is-symbol@1.0.4
├─ is-text-path@1.0.1
├─ is-weakref@1.0.2
├─ isexe@2.0.0
├─ istanbul-lib-coverage@3.2.0
├─ istanbul-reports@3.1.4
├─ js-tokens@4.0.0
├─ json-parse-even-better-errors@2.3.1
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json5@1.0.1
├─ jsonfile@6.1.0
├─ jsonparse@1.3.1
├─ JSONStream@1.3.5
├─ kind-of@6.0.3
├─ lilconfig@2.0.4
├─ lines-and-columns@1.2.4
├─ lint-staged@12.3.7
├─ listr2@4.0.5
├─ local-pkg@0.4.1
├─ locate-path@6.0.0
├─ lodash.merge@4.6.2
├─ log-update@4.0.0
├─ loupe@2.3.4
├─ make-dir@3.1.0
├─ make-error@1.3.6
├─ map-obj@1.0.1
├─ merge-stream@2.0.0
├─ merge2@1.4.1
├─ mimic-fn@2.1.0
├─ min-indent@1.0.1
├─ minimatch@3.1.2
├─ minimist-options@4.1.0
├─ minimist@1.2.6
├─ ms@2.1.2
├─ nanoid@3.3.2
├─ natural-compare@1.4.0
├─ normalize-package-data@3.0.3
├─ normalize-path@3.0.0
├─ npm-run-path@4.0.1
├─ object.assign@4.1.2
├─ object.values@1.1.5
├─ onetime@5.1.2
├─ optionator@0.9.1
├─ p-limit@3.1.0
├─ p-locate@5.0.0
├─ p-map@4.0.0
├─ p-try@1.0.0
├─ parent-module@1.0.1
├─ path-is-absolute@1.0.1
├─ path-key@3.1.1
├─ path-parse@1.0.7
├─ pathval@1.1.1
├─ picocolors@1.0.0
├─ picomatch@2.3.1
├─ pidtree@0.5.0
├─ pinst@3.0.0
├─ postcss@8.4.12
├─ punycode@2.1.1
├─ queue-microtask@1.2.3
├─ quick-lru@4.0.1
├─ read-pkg-up@7.0.1
├─ read-pkg@5.2.0
├─ readable-stream@3.6.0
├─ redent@3.0.0
├─ resolve-global@1.0.0
├─ restore-cursor@3.1.0
├─ reusify@1.0.4
├─ rfdc@1.3.0
├─ rimraf@3.0.2
├─ rollup@2.70.1
├─ run-parallel@1.2.0
├─ rxjs@7.5.5
├─ safe-buffer@5.1.2
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ side-channel@1.0.4
├─ slash@3.0.0
├─ slice-ansi@5.0.0
├─ source-map-js@1.0.2
├─ source-map@0.7.3
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ string_decoder@1.3.0
├─ string-argv@0.3.1
├─ string.prototype.trimend@1.0.4
├─ string.prototype.trimstart@1.0.4
├─ strip-bom@3.0.0
├─ strip-final-newline@2.0.0
├─ strip-indent@3.0.0
├─ strip-json-comments@3.1.1
├─ supports-preserve-symlinks-flag@1.0.0
├─ test-exclude@6.0.0
├─ text-extensions@1.9.0
├─ text-table@0.2.0
├─ through@2.3.8
├─ tinypool@0.1.2
├─ tinyspy@0.3.2
├─ to-regex-range@5.0.1
├─ trim-newlines@3.0.1
├─ ts-node@10.7.0
├─ tsconfig-paths@3.14.1
├─ tslib@1.14.1
├─ type-check@0.4.0
├─ type-detect@4.0.8
├─ type-fest@0.20.2
├─ typescript@4.6.3
├─ unbox-primitive@1.0.1
├─ uri-js@4.4.1
├─ util-deprecate@1.0.2
├─ v8-compile-cache-lib@3.0.0
├─ v8-compile-cache@2.3.0
├─ v8-to-istanbul@8.1.1
├─ vite@2.9.3
├─ vitest@0.9.3
├─ which-boxed-primitive@1.0.2
├─ which@2.0.2
├─ word-wrap@1.2.3
├─ yallist@4.0.0
├─ yaml@1.10.2
├─ yargs-parser@20.2.9
├─ yargs@16.2.0
├─ yn@3.1.1
└─ yocto-queue@0.1.0
Done in 6.63s.
```



</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.18
0 vulnerabilities found - Packages audited: 428
Done in 0.51s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)